### PR TITLE
Update documentation link in README to point to plugin docs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -10,7 +10,7 @@ Internally, the plugin is a wrapper around the [Terraform CLI](https://github.co
 
 ## Documentation
 
-For installation and usage, please [visit our docs](https://go-vela.github.io/docs).
+For installation and usage, please [visit our docs](https://go-vela.github.io/docs/plugins/registry/pipeline/terraform/).
 
 ## Contributing
 


### PR DESCRIPTION
Hi!

I've found it annoying that my browser history (which points to `go-vela/vela-terraform` on GitHub) doesn't get me to the Vela Terraform Plugin docs in one click.

Currently, I have to go to the overall Vela docs and then traverse the navigation menu to find the Terraform docs.

This PR is a suggestion I think would be helpful; merely to link directly to the Terraform plugin's page on the docsite.

If there's a reason this hasn't been done before, I'm all ears.

Thanks!